### PR TITLE
Добавлены манифесты для namespace и deployment

### DIFF
--- a/kubernetes-controllers/deployment.yaml
+++ b/kubernetes-controllers/deployment.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-homework-config
+  namespace: homework
+data:
+  default.conf: |
+    server {
+        listen 8000;
+        location / {
+            root /homework;
+            index index.html;
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: homework
+  labels:
+    app: homework-web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: homework-web
+  template:
+    metadata:
+      labels:
+        app: homework-web
+    spec:
+      nodeSelector:
+        homework: "true" # Удали этот блок, если не хочешь ограничивать по нодам
+      volumes:
+        - name: shared-volume
+          emptyDir: {}
+        - name: nginx-config
+          configMap:
+            name: nginx-homework-config
+      initContainers:
+        - name: init-downloader
+          image: busybox
+          command:
+            - sh
+            - -c
+            - |
+              echo "<html><body><h1>Hello from /homework!</h1></body></html>" > /init/index.html
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /init
+      containers:
+        - name: nginx
+          image: nginx:stable-alpine
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "200m"
+            limits:
+              memory: "512Mi"
+              cpu: "400m"
+          readinessProbe:
+            exec:
+              command:
+                - cat
+                - /homework/index.html
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /homework
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - rm -f /homework/index.html
+          ports:
+            - containerPort: 8000
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: homework-service
+  namespace: homework
+spec:
+  type: NodePort
+  selector:
+    app: homework-web
+  ports:
+    - port: 8000
+      targetPort: 8000
+      nodePort: 30080

--- a/kubernetes-controllers/namespace.yaml
+++ b/kubernetes-controllers/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework


### PR DESCRIPTION
# Выполнено ДЗ № 2

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - Пункт 1 Создан файл-манифест namespaces.yaml, описывающий создание namespace
 - Пункт 2 Создан файл-манифест deployments.yaml, описывающий deployment, 
 с требованиями, указанными в Д3:
 - Запуск трех экземпляров подов, соответствующих спецификации из ДЗ №1
 - Readiness probe, которая проверяет наличие файла index.html в директории /homework
 - Стратегию обновления RollingUpdate, в которой при обновлении будет недоступен максимум один под.
 - Спецификацию, обеспечивающую запуск подов деплоймента только на нодах кластера, имеющих метку homework=true

## Как запустить проект:
 - kubectl apply -f namespace.yaml
 - kubectl apply -f deployment.yaml

## Как проверить работоспособность:
 - Например, перейти по ссылке http://<node-ip>:30080

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
