### PR TITLE
Добавлены файлы для ДЗ №5

### DIFF
--- a/kubernetes-security/cd-kubeconfig
+++ b/kubernetes-security/cd-kubeconfig
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+clusters:
+  - name: minikube
+    cluster:
+      certificate-authority-data:
+      server: https://192.168.59.108:8443
+contexts:
+  - name: cd@minikube
+    context:
+      cluster: minikube
+      namespace: homework
+      user: cd
+current-context: cd@minikube
+users:
+  - name: cd
+    user:
+      token: eyJhbGciOiJSUzI1NiIsImtpZCI6InFTQUE0YUY5cTl2WTdYVmsyVTJzeXVUY2tRM05NNkQ5YVN1YWZyeG9HbUUifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiXSwiZXhwIjoxNzQ3NjczOTk4LCJpYXQiOjE3NDc1ODc1OTgsImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwianRpIjoiMzM5YjBjYTktODQ3NC00N2I5LTg4ZDYtZjJmNDFhODVhNjE1Iiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJob21ld29yayIsInNlcnZpY2VhY2NvdW50Ijp7Im5hbWUiOiJjZCIsInVpZCI6IjkxZjgyMjNhLTdhMDQtNGQ2Mi1iNTgwLTQzY2M5Y2U4YWYzMyJ9fSwibmJmIjoxNzQ3NTg3NTk4LCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6aG9tZXdvcms6Y2QifQ.L-9knjECbwmwOsuzKWKrumbGb_qowkoyBFIn-z1qWdOx7lUgSGxti6nXapZt1xVyk7Jwk1qAit4nPoylGek228hNz57E5HV-imGhdnXxwiFXlOh4y-JKOcjZPWOS112lUXWNldaEVqQahIvq0PjtXHq3GQZIUmynyjOMmEYmDlv0eenncCb3t2PG4cyJEy7q5QZrBkngbyalOvISemUX5q4lOs738M-xL620wTl8bSv_hDlxeWbnbkIMcHtGdiuxNmiR5Ate9QfTfCC6vJ2z8WTT0WgfkfuSuK6oenzqy1-1oV_XL8JvUn54SxCVTl9M1ba33i6OubAwLDgmHv2DXg

--- a/kubernetes-security/cd.yaml
+++ b/kubernetes-security/cd.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cd
+  namespace: homework
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cd-admin-binding
+  namespace: homework
+subjects:
+  - kind: ServiceAccount
+    name: cd
+    namespace: homework
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-security/cm.yaml
+++ b/kubernetes-security/cm.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: homework-config
+  namespace: homework
+data:
+  user: password
+  foo: bar
+  somekey: somevalue

--- a/kubernetes-security/deployment.yaml
+++ b/kubernetes-security/deployment.yaml
@@ -1,0 +1,141 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-homework-config
+  namespace: homework
+data:
+  default.conf: |
+    server {
+        listen 80;
+
+        location / {
+            root /homework;
+            index index.html;
+        }
+
+        location /metrics.html {
+            alias /homework/metrics.html;
+            default_type text/plain;
+        }
+
+        location /conf/file {
+            alias /homework/generated/file;
+            default_type text/plain;
+        }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: homework
+  labels:
+    app: homework-web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: homework-web
+  template:
+    metadata:
+      labels:
+        app: homework-web
+    spec:
+      serviceAccountName: monitoring
+      nodeSelector:
+        homework: "true"
+      volumes:
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: homework-pvc
+        - name: nginx-config
+          configMap:
+            name: nginx-homework-config
+        - name: homework-config-volume
+          configMap:
+            name: homework-config
+      initContainers:
+        - name: init-downloader
+          image: busybox
+          command:
+            - sh
+            - -c
+            - |
+              echo "<html><body><h1>Hello from /homework!</h1></body></html>" > /init/index.html
+              mkdir -p /init/generated
+              > /init/generated/file
+              for f in /config/*; do
+                echo "$(basename $f): $(cat $f)" >> /init/generated/file
+              done
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /init
+            - name: homework-config-volume
+              mountPath: /config
+      containers:
+        - name: nginx
+          image: nginx:stable-alpine
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "200m"
+            limits:
+              memory: "512Mi"
+              cpu: "400m"
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 80
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /homework
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+            - name: homework-config-volume
+              mountPath: /homework/conf
+              readOnly: True
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - rm -f /homework/index.html
+          ports:
+            - containerPort: 80
+
+        - name: metrics-fetcher
+          image: curlimages/curl
+          env:
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          command:
+            - sh
+            - -c
+            - |
+              while true; do
+                # Запрашиваем метрики у Kubelet (используем токен ServiceAccount)
+                TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+                curl -s -k -H "Authorization: Bearer $TOKEN" "https://${NODE_IP}:10250/metrics" > /homework/metrics.html
+                sleep 30  # Обновляем каждые 30 секунд
+              done
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /homework
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1

--- a/kubernetes-security/ingress.yaml
+++ b/kubernetes-security/ingress.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: homework-ingress
+  namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: homework.otus
+      http:
+        paths:
+          - path: /homepage(/|$)(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: homework-service
+                port:
+                  number: 80
+          - path: /()(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: homework-service
+                port:
+                  number: 80

--- a/kubernetes-security/monitoring-role.yaml
+++ b/kubernetes-security/monitoring-role.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubelet-metrics-reader
+rules:
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["nodes/metrics"]
+    verbs: ["get", "list"]

--- a/kubernetes-security/monitoring-rolebinding.yaml
+++ b/kubernetes-security/monitoring-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: monitoring-kubelet-reader
+subjects:
+  - kind: ServiceAccount
+    name: monitoring
+    namespace: homework
+roleRef:
+  kind: ClusterRole
+  name: kubelet-metrics-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-security/monitoring-sa.yaml
+++ b/kubernetes-security/monitoring-sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    kubernetes.io/enforce-mountable-secrets: "true"
+  name: monitoring
+  namespace: homework

--- a/kubernetes-security/namespace.yaml
+++ b/kubernetes-security/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-security/pvc.yaml
+++ b/kubernetes-security/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: homework-pvc
+  namespace: homework
+spec:
+  storageClassName: minikube-hostpath-retain
+  resources:
+    requests:
+      storage: 1Gi
+  accessModes:
+    - ReadWriteOnce

--- a/kubernetes-security/service.yaml
+++ b/kubernetes-security/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: homework
+  name: homework-service
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      protocol: TCP
+  selector:
+    app: homework-web

--- a/kubernetes-security/storageClass.yaml
+++ b/kubernetes-security/storageClass.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: minikube-hostpath-retain
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Retain
+volumeBindingMode: Immediate


### PR DESCRIPTION
# Выполнено ДЗ № 5

 - [ ] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - Cоздан файл monitoring-sa в котором описан service account мониторинг.
 - Cозданы файлы monitoring-role и monitoring-rolebinding в которых описаны cluster role и cluster role binding для service account monitoring.
 - В манифест deployment.yaml в specs добавлена строка serviceAccountName: monitoring в раздел specs.
 - Создан файл cd.yaml в котором находятся манифесты для serviceaccount cd, а так же role binding для него.
 - Создан kubeconfig ( файл cd-kubeconfig ) для serviceaccount cd.
 - Сгенерирован токен для serviceaccount cd с временем действия в 1 день, сохранен сразу в файл cd-kubeconfig
 - В deployment.yaml добавлен дополнительный контейнер metrics-fetcher, с которого выполняются запросы на /metrics для того, чтобы сохранять данные в metrics.html. Так же модифицирован конфиг nginx - был добавлен эндпойнт /metrics.html

## Как запустить проект:
 - kubectl apply -f .\kubernetes-security\namespace.yaml
 - kubectl apply -f .\kubernetes-security\monitoring-sa.yaml
 - kubectl apply -f .\kubernetes-security\cd.yaml
 - kubectl apply -f .\kubernetes-security\monitoring-role.yaml
 - kubectl apply -f .\kubernetes-security\monitoring-rolebinding.yaml
 - kubectl apply -f .\kubernetes-security\service.yaml
 - kubectl apply -f .\kubernetes-security\storageClass.yaml
 - kubectl apply -f .\kubernetes-security\pvc.yaml
 - kubectl apply -f .\kubernetes-security\ingress.yaml
 - kubectl apply -f .\kubernetes-security\cm.yaml
 - kubectl apply -f .\kubernetes-security\deployment.yaml

## Как проверить работоспособность:
 - Доступность /metrics.html - http://homework.otus/metrics.html
 - Работоспособность cd аккаунта - залить конфиг cd-kubeconfig в директорию .kube, и сделать kubectl config use-context cd@minikube. Затем попробовать сделать kubectl get pods -n homework. И тоже самое для namespace default.

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
